### PR TITLE
Improvements

### DIFF
--- a/endpoint_task_list.py
+++ b/endpoint_task_list.py
@@ -11,9 +11,14 @@ import time
 import os
 import json
 import webbrowser
-import pprint
+import shutil
 import sys
+
+from getpass import getpass
+
 import globus_sdk
+
+
 
 # some globals
 CLIENT_ID = '231634e4-37cc-4a06-96ce-12a262a62da7'
@@ -21,7 +26,6 @@ DEBUG = 0
 TIMEOUT = 60
 MB = 1048576
 NOTIFY_SIZE = 100000
-RECIPIENTS = "gwarnold@illinois.edu,gbauer@illinois.edu"
 RECIPIENTS = "gwarnold@illinois.edu,help+bwstorage@ncsa.illinois.edu"
 GLOBUS_CONSOLE = "https://www.globus.org/app/console/tasks/"
 SUPPORT_EMAIL = "help+bw@ncsa.illinois.edu"
@@ -36,9 +40,15 @@ REDIRECT_URI = 'https://auth.globus.org/v2/web/auth-code'
 SCOPES = 'openid email profile urn:globus:auth:scope:transfer.api.globus.org:all'
 # endpoints determined by globus cli: globus endpoint search ncsa#jyc
 #  or from globus.org -> "Manage Endpoints" -> endpoint detail, UUID
-EP_BW = "d59900ef-6d04-11e5-ba46-22000b92c6ec"
-EP_JYC = "d0ccdc02-6d04-11e5-ba46-22000b92c6ec"
-EP_NEARLINE = "d599008e-6d04-11e5-ba46-22000b92c6ec"
+ENDPOINTS = {
+    'BW' : "d59900ef-6d04-11e5-ba46-22000b92c6ec",
+    'JYC' : "d0ccdc02-6d04-11e5-ba46-22000b92c6ec",
+    'NEARLINE' : "d599008e-6d04-11e5-ba46-22000b92c6ec"
+    }
+
+TASK_DETAIL_FILE = "task_detail.txt"
+LARGE_TRANSFER_FILE = "large_xfer.txt"
+# TOKENS_NOT_SAVED = False
 
 
 def is_remote_session():
@@ -48,16 +58,25 @@ def is_remote_session():
 
 def load_tokens_from_file(filepath):
     """Load a set of saved tokens."""
-    with open(filepath, 'r') as tokenfile:
-        tokens = json.load(tokenfile)
-
+    tokens = None
+    try:
+        with open(filepath, 'r') as tokenfile:
+            tokens = json.load(tokenfile)
+    except FileNotFoundError:
+        pass
+    except BaseException:
+        sys.stderr.write("Failed to read tokens from {}\n".format(filepath))
     return tokens
 
 
 def save_tokens_to_file(filepath, tokens):
     """Save a set of tokens for later use."""
-    with open(filepath, 'w') as tokenfile:
-        json.dump(tokens, tokenfile)
+    try:
+        with open(filepath, 'w') as tokenfile:
+            json.dump(tokens, tokenfile)
+    except BaseException:
+        sys.stderr.write("Failed while saving tokens to {}\n".format(filepath))
+        # TOKENS_NOT_SAVED = True
 
 
 def update_tokens_file_on_refresh(token_response):
@@ -82,12 +101,12 @@ def do_native_app_authentication(client_id, redirect_uri,
 
     url = client.oauth2_get_authorize_url()
 
-    print('Native App Authorization URL: \n{}'.format(url))
+    print('Native App Authorization URL:\n{}'.format(url))
 
     if not is_remote_session():
         webbrowser.open(url, new=1)
 
-    auth_code = input('Enter the auth code: ').strip()
+    auth_code = getpass('Enter the auth code: ')
 
     token_response = client.oauth2_exchange_code_for_tokens(auth_code)
 
@@ -99,12 +118,14 @@ def add_notification_line(task, endpoint_is):
     """
     Append task info to a file to send vial email.
     """
-    mail_file = open('large_xfer.txt', 'a')
-    mail_file.write("{1:5s} {2:36s} {3:10d} {0}\n".format(
-        task["owner_string"], endpoint_is,
+    output = "{1:5s} {2:36s} {3:10d} {0}\n".format(
+        task["owner_string"],
+        endpoint_is,
         task["task_id"],
-        task["files"]))
-    mail_file.close()
+        task["files"])
+    with open(LARGE_TRANSFER_FILE, 'a') as mail_file:
+        mail_file.write(output)
+
 
 
 def build_go_notify_string_size(task):
@@ -157,6 +178,7 @@ def my_endpoint_manager_task_list(tclient, endpoint):
     for task in tclient.endpoint_manager_task_list(filter_endpoint=endpoint,
                                                    filter_status="ACTIVE",
                                                    num_results=None):
+
         if task["destination_endpoint_id"] == endpoint:
             endpoint_is = "DEST"
             dest_total_files += task["files"]
@@ -167,6 +189,7 @@ def my_endpoint_manager_task_list(tclient, endpoint):
             source_total_files += task["files"]
             source_total_bps += task["effective_bytes_per_second"]
             source_total_tasks += 1
+
         if task["destination_endpoint_id"] == task["source_endpoint_id"]:
             if task["files"] > SRCDEST_FILES:
                 if MYTASKPAUSED.get(str(task["task_id"])) is None:
@@ -175,25 +198,28 @@ def my_endpoint_manager_task_list(tclient, endpoint):
                                                              build_go_notify_string_dest(task))
                     print("{} for {} PAUSED.".format(task["task_id"], task["owner_string"]))
                     globus_url = GLOBUS_CONSOLE + str(task["task_id"])
-                    detail_file = open('task_detail.txt', 'w')
+                    detail_file = open(TASK_DETAIL_FILE, 'w')
                     detail_file.write("Click link to view in the GO console: {}\n".
                                       format(globus_url))
-                    pprint.pprint(str(task), stream=detail_file, depth=1, width=50)
+                    print(json.dumps(task.data, sort_keys=True, indent=4), file=detail_file)
                     detail_file.close()
-                    os.system("mail -s " + "PAUSED_SRC=DEST:" + task["owner_string"] +
-                              " " + RECIPIENTS + " < task_detail.txt")
+                    os.system("mail -s PAUSED_SRC=DEST:{} {} < {}".format(task["owner_string"], RECIPIENTS, TASK_DETAIL_FILE))
                     MYTASKPAUSED[str(task["task_id"])] = 1
                 else:
                     print("{} for {} was already PAUSED.".format(task["task_id"],
                                                                  task["owner_string"]))
                     continue
+
             endpoint_is = "DEST_SRC"
+
             dest_total_files += task["files"]
             dest_total_bps += task["effective_bytes_per_second"]
             dest_total_tasks += 1
+
             source_total_files += task["files"]
             source_total_bps += task["effective_bytes_per_second"]
             source_total_tasks += 1
+
         if (task["files"] > PAUSE_SIZE) and (endpoint_is == "DEST"):
             if MYTASKPAUSED.get(str(task["task_id"])) is None:
                 if not task["is_paused"]:
@@ -201,13 +227,11 @@ def my_endpoint_manager_task_list(tclient, endpoint):
                                                          build_go_notify_string_size(task))
                 print("{} for {} PAUSED.".format(task["task_id"], task["owner_string"]))
                 globus_url = GLOBUS_CONSOLE + str(task["task_id"])
-                detail_file = open('task_detail.txt', 'w')
-                detail_file.write("Click link to view in the GO console: {}\n".
-                                  format(globus_url))
-                pprint.pprint(str(task), stream=detail_file, depth=1, width=50)
-                detail_file.close()
-                os.system("mail -s " + "PAUSED_NFILES:" + task["owner_string"] +
-                          " " + RECIPIENTS + " < task_detail.txt")
+                with open(TASK_DETAIL_FILE, 'w') as detail_file:
+                    detail_file.write("Click link to view in the GO console: {}\n".
+                                      format(globus_url))
+                    print(json.dumps(task.data, sort_keys=True, indent=4), file=detail_file)
+                os.system("mail -s PAUSED_NFILES:{} {} < {}".format(task["owner_string"], RECIPIENTS, TASK_DETAIL_FILE))
                 MYTASKPAUSED[str(task["task_id"])] = 1
             else:
                 print("{} for {} was already PAUSED.".format(task["task_id"],
@@ -231,21 +255,13 @@ def main():
     """
     main program
     """
-    tokens = None
-    try:
-        # if we already have tokens, load and use them
-        tokens = load_tokens_from_file(TOKEN_FILE)
-    except IOError:
-        pass
+
+    tokens = load_tokens_from_file(TOKEN_FILE)
 
     if not tokens:
         # if we need to get tokens, start the Native App authentication process
         tokens = do_native_app_authentication(CLIENT_ID, REDIRECT_URI, SCOPES)
-
-        try:
-            save_tokens_to_file(TOKEN_FILE, tokens)
-        except IOError:
-            sys.stderr.write("There was an error trying to save tokens to {}.".format(TOKEN_FILE))
+        save_tokens_to_file(TOKEN_FILE, tokens)
 
     transfer_tokens = tokens['transfer.api.globus.org']
 
@@ -262,12 +278,17 @@ def main():
 
     while True:
         print("...Nearline..........task.[ACTIVE]............Nfiles.....owner...")
-        my_endpoint_manager_task_list(tclient, EP_NEARLINE)
-        if os.path.isfile("./large_xfer.txt"):
-            print("found large_xfer.txt, handling...")
-            os.system("cat -n large_xfer.txt")
-#           os.system("mail -s ncsa#Nearline_many_file_xfers " + RECIPIENTS + " < ./large_xfer.txt")
-            os.system("rm large_xfer.txt")
+        my_endpoint_manager_task_list(tclient, ENDPOINTS['NEARLINE'])
+
+        try:
+            with open(LARGE_TRANSFER_FILE, "r") as ltf:
+                shutil.copyfileobj(ltf, sys.stdout)
+            os.remove(LARGE_TRANSFER_FILE)
+        except FileNotFoundError:
+            pass
+        except BaseException:
+            sys.stderr.write("Failed to read from {}".format(LARGE_TRANSFER_FILE))
+
         print("...sleeping {}s...\n".format(SLEEP_DELAY))
         time.sleep(SLEEP_DELAY)
         # end while


### PR DESCRIPTION
According to [this](https://jira.ncsa.illinois.edu/browse/BWSTOR-1549), we're dealing with GlobusResponse objects. And according to [this page](https://globus-sdk-python.readthedocs.io/en/stable/responses/), these objects have only one `data` member. Thus, we should be able to access them as `task.data` and `print` them using `json.dumps` (not to be confused with `json.dump`)